### PR TITLE
Fix Android values dir name for regions

### DIFF
--- a/master.cfg.py
+++ b/master.cfg.py
@@ -631,6 +631,7 @@ def MakeAndroidRemoteTransifexPoPullBuilder():
   AddAndroidRemoteTxSetup(f)
   f.addStep(ShellCommand(name="tx_pull", workdir="build", haltOnFailure=True,
                          command=["tx", "pull", "-a", "--force"]))
+  f.addStep(ShellCommand(name="rename_res", workdir="build", haltOnFailure=True, command="rename 's/_/-r/g' app/res/values-*"))
   f.addStep(ShellCommand(name="git_add", workdir="build", haltOnFailure=True, command="git add --verbose app/res/values-*"))
   f.addStep(ShellCommand(name="git_commit", workdir="build", haltOnFailure=True, command=["git", "commit", "--author=Clementine Buildbot <buildbot@clementine-player.org>", "--message=Automatic merge of translations from Transifex (https://www.transifex.com/projects/p/clementine-remote/resource/clementine-remote)"]))
   f.addStep(ShellCommand(name="git_push",   workdir="build", haltOnFailure=True, command=["git", "push", "git@github.com:clementine-player/Android-Remote.git", "master", "--verbose"]))


### PR DESCRIPTION
The automatic translation merge from [Transifex](https://www.transifex.com/projects/p/clementine-remote) creates values folders with an underscore, e.g.:

```
values-ms_MY
```

Android expects a hyphen-minus, followed by `r` (see [Providing Alternative Resources](http://developer.android.com/guide/topics/resources/providing-resources.html#AlternativeResources)):

```
values-ms-rMY
```

This PR fixes it by renaming the folders right before committing the automatic translation merge.
