### PR TITLE
Update paths of Android res folders

### DIFF
--- a/master.cfg.py
+++ b/master.cfg.py
@@ -583,8 +583,8 @@ def AddWebsiteTxSetup(f):
 
 def AddAndroidRemoteTxSetup(f, pot=True):
   AddTxSetup(f, "clementine-remote.clementine-remote",
-      "app/res/values/strings.xml",
-      "app/res/values-<lang>/strings.xml")
+      "app/src/main/res/values/strings.xml",
+      "app/src/main/res/values-<lang>/strings.xml")
 
 def MakeWebsiteTransifexPotPushBuilder():
   f = factory.BuildFactory()
@@ -631,8 +631,8 @@ def MakeAndroidRemoteTransifexPoPullBuilder():
   AddAndroidRemoteTxSetup(f)
   f.addStep(ShellCommand(name="tx_pull", workdir="build", haltOnFailure=True,
                          command=["tx", "pull", "-a", "--force"]))
-  f.addStep(ShellCommand(name="rename_res", workdir="build", haltOnFailure=True, command="rename 's/_/-r/g' app/res/values-*"))
-  f.addStep(ShellCommand(name="git_add", workdir="build", haltOnFailure=True, command="git add --verbose app/res/values-*"))
+  f.addStep(ShellCommand(name="rename_res", workdir="build", haltOnFailure=True, command="rename 's/_/-r/g' app/src/main/res/values-*"))
+  f.addStep(ShellCommand(name="git_add", workdir="build", haltOnFailure=True, command="git add --verbose app/src/main/res/values-*"))
   f.addStep(ShellCommand(name="git_commit", workdir="build", haltOnFailure=True, command=["git", "commit", "--author=Clementine Buildbot <buildbot@clementine-player.org>", "--message=Automatic merge of translations from Transifex (https://www.transifex.com/projects/p/clementine-remote/resource/clementine-remote)"]))
   f.addStep(ShellCommand(name="git_push",   workdir="build", haltOnFailure=True, command=["git", "push", "git@github.com:clementine-player/Android-Remote.git", "master", "--verbose"]))
   return f


### PR DESCRIPTION
Updates the location of the Android `res` folder to follow standard Android Gradle layout (`src/main/res`)

This should be merged **after** https://github.com/clementine-player/Android-Remote/pull/120.
