### PR TITLE
Remove Android regional res folders before rename

### DIFF
--- a/master.cfg.py
+++ b/master.cfg.py
@@ -631,6 +631,7 @@ def MakeAndroidRemoteTransifexPoPullBuilder():
   AddAndroidRemoteTxSetup(f)
   f.addStep(ShellCommand(name="tx_pull", workdir="build", haltOnFailure=True,
                          command=["tx", "pull", "-a", "--force"]))
+  f.addStep(ShellCommand(name="remove_res", workdir="build", haltOnFailure=True, command="rm -rf app/src/main/res/values-??-r*"))
   f.addStep(ShellCommand(name="rename_res", workdir="build", haltOnFailure=True, command="rename 's/_/-r/g' app/src/main/res/values-*"))
   f.addStep(ShellCommand(name="git_add", workdir="build", haltOnFailure=True, command="git add --verbose app/src/main/res/values-*"))
   f.addStep(ShellCommand(name="git_commit", workdir="build", haltOnFailure=True, command=["git", "commit", "--author=Clementine Buildbot <buildbot@clementine-player.org>", "--message=Automatic merge of translations from Transifex (https://www.transifex.com/projects/p/clementine-remote/resource/clementine-remote)"]))


### PR DESCRIPTION
`rename` will not rename the folders if the target folder already exists! The solution is to first remove all region specific values folders (**values-??-r***), before renaming the folders pulled from Transifex.
