### PR TITLE
Use buildbot 0.8.14 to prevent master container from exiting. fix #8

### DIFF
--- a/master/Dockerfile
+++ b/master/Dockerfile
@@ -1,7 +1,7 @@
 from ubuntu
 
 run apt-get update && apt-get install -y python-pip python-dev git
-run pip install sqlalchemy==0.7.10 buildbot
+run pip install sqlalchemy==0.7.10 buildbot==0.8.14
 
 run useradd -r -s /bin/false buildbot
 


### PR DESCRIPTION
pip will install buildbot 0.9.x but that has some breaking api changes so start.py will fail and the master container will exit.